### PR TITLE
fix bug when opening derived results

### DIFF
--- a/allesfitter/__init__.py
+++ b/allesfitter/__init__.py
@@ -129,11 +129,11 @@ class allesclass():
             
         #::: nested sampling derived results?
         if os.path.exists( os.path.join(config.BASEMENT.outdir,'ns_derived_samples.pickle') ):
-            self.posterior_derived_params = pickle.load(open(os.path.join(datadir,'ns_derived_samples.pickle'),'rb'))
+            self.posterior_derived_params = pickle.load(open(os.path.join(config.BASEMENT.outdir,'ns_derived_samples.pickle'),'rb'))
             
         #::: mcmc derived results?
         elif os.path.exists( os.path.join(config.BASEMENT.outdir,'mcmc_derived_samples.pickle') ):
-            self.posterior_derived_params = pickle.load(open(os.path.join(datadir,'mcmc_derived_samples.pickle'),'rb'))
+            self.posterior_derived_params = pickle.load(open(os.path.join(config.BASEMENT.outdir,'mcmc_derived_samples.pickle'),'rb'))
             
         #::: else
         else:


### PR DESCRIPTION
A path if checks for existence, but then a different path is used to open the file.

Aims to fix https://github.com/MNGuenther/allesfitter/issues/57